### PR TITLE
Recoded MySecretKey.java to UTF-8

### DIFF
--- a/cloudgene.cluster/src/cloudgene/util/MySecretKey.java
+++ b/cloudgene.cluster/src/cloudgene/util/MySecretKey.java
@@ -14,7 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 public class MySecretKey {
-	public static final String key = "¾}k A¼(8¦§ð+o";
+	public static final String key = "Å¸}k AÅ’(8Å Â§Ã°+o";
 
 	public static void generateKey() {
 		byte[] key = null;

--- a/cloudgene.mapred/src/cloudgene/mapred/util/MySecretKey.java
+++ b/cloudgene.mapred/src/cloudgene/mapred/util/MySecretKey.java
@@ -14,7 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.codec.binary.Base64;
 
 public class MySecretKey {
-	public static final String key = "¾}k A¼(8¦§ð+o";
+	public static final String key = "Å¸}k AÅ’(8Å Â§Ã°+o";
 
 	public static void generateKey() {
 		byte[] key = null;


### PR DESCRIPTION
Perhaps this is the best way to fix the encoding problem. 
I only had problems with this file. 
Running "recode" 

recode ISO-8859-15..UTF8 cloudgene/cloudgene.cluster/src/cloudgene/util/MySecretKey.java

Fixed this.
Perhaps every source file should be in UTF-8 for better multi OS support? 

cheers
